### PR TITLE
Adds support for downloading and installing the latest version of Rainway

### DIFF
--- a/setup2.ps1
+++ b/setup2.ps1
@@ -12,6 +12,5 @@ Disable-Devices
 Enable-Audio
 Install-VirtualAudio
 Install-Steam
-Install-Rainway
 Add-AutoLogin $admin_username $admin_password
 Restart-Computer

--- a/setup2.ps1
+++ b/setup2.ps1
@@ -12,5 +12,6 @@ Disable-Devices
 Enable-Audio
 Install-VirtualAudio
 Install-Steam
+Install-Rainway
 Add-AutoLogin $admin_username $admin_password
 Restart-Computer

--- a/utils.psm1
+++ b/utils.psm1
@@ -1,6 +1,6 @@
 [Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
 $webClient = new-object System.Net.WebClient
-
+$webClient.Headers.Add("user-agent", "Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0")
 function Disable-InternetExplorerESC {
     # From https://stackoverflow.com/questions/9368305/disable-ie-security-on-windows-server-via-powershell
     $AdminKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A7-37EF-4b3f-8CFC-4F3A74704073}"
@@ -9,6 +9,40 @@ function Disable-InternetExplorerESC {
     Set-ItemProperty -Path $UserKey -Name "IsInstalled" -Value 0 -Force
     Stop-Process -Name Explorer -Force
     Write-Output "IE Enhanced Security Configuration (ESC) has been disabled." -ForegroundColor Green
+}
+
+function Download-File($displayName, $description, $url, $output) {
+    Import-Module BitsTransfer
+    Start-BitsTransfer -Source $url -Destination $output -DisplayName $displayName -Description $description
+}
+
+
+function Install-Rainway {
+    if ((New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        $rainwayRelease = Invoke-WebRequest 'https://releases.rainway.io/Installer_current.json' | ConvertFrom-Json
+        if (!$rainwayRelease) {
+            Write-Host "Failed to fetch remote Rainway config" -ForegroundColor Red
+            return
+        }
+        $version = $rainwayRelease.Version
+        $url = "https://releases.rainway.io/Installer_$version.exe"
+        $downloadedFile = "$PSScriptRoot\RainwayInstaller.exe"
+
+        $description = "Rainway is a web based game streaming platform that lets you play your favorite PC games anywhere. Learn more at rainway.io"
+        Download-File  -displayName  "Downloading Rainway ($version)" -description $description -url $url -output $downloadedFile
+     
+
+        Unblock-File -Path $downloadedFile
+
+        Write-Output "Installing Rainway ($version) from file $downloadedFile"
+        Start-Process -FilePath $downloadedFile -ArgumentList "/qn" -Wait
+
+        Write-Output "Cleaning up Rainway installation file"
+        Remove-Item -Path $downloadedFile -Confirm:$false
+    }
+    else {
+        Write-Host "You must be running as administrator to install Rainway." -ForegroundColor Red 
+    }
 }
 
 function Update-Windows {
@@ -129,7 +163,7 @@ function Install-VirtualAudio {
 function Install-Chocolatey {
     Write-Output "Installing Chocolatey"
     Invoke-Expression ($webClient.DownloadString('https://chocolatey.org/install.ps1'))
-    $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine")
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine")
     chocolatey feature enable -n allowGlobalConfirmation
 }
 
@@ -151,7 +185,7 @@ function Install-VPN {
 
     Write-Output "Installing ZeroTier"
     choco install zerotier-one --force
-    $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine")
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine")
 }
 
 function Join-Network ($network) {


### PR DESCRIPTION
Hey there,

First, let me say thank you for putting this script together. I'm sure it will do wonders for those looking to spin up their gaming rigs on Azure. 

I noticed you were installing a VPN on the system so you could use Steam In-Home Streaming. That seemed pretty inefficient from a latency standpoint, so I forked and added a function for downloading and installing the latest version of [Rainway](https://rainway.io/).

Rainway is a web-based game streaming platform that lets you play all your favorite PC games from Steam, Origin and other platforms anywhere. 

I didn't see your security group policy, but here are the ports it uses so you can make sure they're allowed.

TCP 443
TCP 40136
UDP 22000–22010
