### PR TITLE
Create the disconnect shortcut on the desktop

### DIFF
--- a/utils.psm1
+++ b/utils.psm1
@@ -209,10 +209,10 @@ function Disable-ScheduleWorkflow {
 
 function Add-DisconnectShortcut {
     # From https://stackoverflow.com/questions/9701840/how-to-create-a-shortcut-using-powershell
-    Write-Output "Create disconnect shortcut under C:\disconnect.lnk"
+    Write-Output "Create disconnect shortcut on the desktop"
 
     $WshShell = New-Object -comObject WScript.Shell
-    $Shortcut = $WshShell.CreateShortcut("C:\disconnect.lnk")
+    $Shortcut = $WshShell.CreateShortcut("C:\Users\Public\Desktop\disconnect.lnk")
     $Shortcut.TargetPath = "C:\Windows\System32\tscon.exe"
     $Shortcut.Arguments = "1 /dest:console"
     $Shortcut.Save()


### PR DESCRIPTION
Could close #28 and could close #37 by improving the discoverability of the disconnect shortcut

- [x] The disconnect shortcut is now created in the Public desktop, which is included in any user's desktop on the machine.

- [x] Test proper behavior on a WS2016 environment.